### PR TITLE
remove unused strdup, strerror, _doprnt compat

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -365,16 +365,6 @@ char *alloca ();
 #endif
 ])])
 
-AC_DEFUN([LSH_FUNC_STRERROR],
-[AC_CHECK_FUNCS(strerror)
-AH_BOTTOM(
-[#if HAVE_STRERROR
-#define STRERROR strerror
-#else
-#define STRERROR(x) (sys_errlist[x])
-#endif
-])])
-
 AC_DEFUN([LSH_FUNC_STRSIGNAL],
 [AC_CHECK_FUNCS(strsignal)
 AC_CHECK_DECLS([sys_siglist, _sys_siglist])

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,6 @@ LSH_GCC_ATTRIBUTES
 # Checks for library functions.
 AC_FUNC_ALLOCA
 AC_FUNC_VPRINTF
-AC_CHECK_FUNCS(strerror)
 
 AC_REPLACE_FUNCS(mempcpy strndup strchrnul)
 
@@ -72,7 +71,7 @@ AC_CHECK_DECL(flockfile)
 AC_CHECK_DECLS([fputs_unlocked, fwrite_unlocked])
 
 # Used only by argp-test.c, so don't use AC_REPLACE_FUNCS.
-AC_CHECK_FUNCS(strdup asprintf)
+AC_CHECK_FUNCS(asprintf)
 
 AC_CHECK_DECLS([program_invocation_name, program_invocation_short_name],
                [], [], [[#include <errno.h>]])

--- a/meson_config.h.in
+++ b/meson_config.h.in
@@ -26,9 +26,6 @@
    and to 0 if you don't. */
 #undef HAVE_DECL_PROGRAM_INVOCATION_SHORT_NAME
 
-/* Define to 1 if you don't have `vprintf' but do have `_doprnt.' */
-#undef HAVE_DOPRNT
-
 /* Define to 1 if you have the `flockfile' function. */
 #undef HAVE_FLOCKFILE
 
@@ -64,12 +61,6 @@
 
 /* Define to 1 if you have the `strchrnul' function. */
 #undef HAVE_STRCHRNUL
-
-/* Define to 1 if you have the `strdup' function. */
-#undef HAVE_STRDUP
-
-/* Define to 1 if you have the `strerror' function. */
-#undef HAVE_STRERROR
 
 /* Define to 1 if you have the <strings.h> header file. */
 #undef HAVE_STRINGS_H


### PR DESCRIPTION
strdup is POSIX and provided by UCRT, MSVCRT, and all the free unices.
strerror is a standard C99 function.

I don't know what _doprnt even is but it's not mentioned outside
_meson_config.h.in_.

I've build tested this on OpenBSD and Alpine Linux with Meson and Autotools.
I have some questions about the portability code, I'll send them in a separate comment.