### PR TITLE
fix compilation with mingw

### DIFF
--- a/argp-parse.c
+++ b/argp-parse.c
@@ -44,6 +44,9 @@ alloca();
 #endif
 #endif
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #if defined(HAVE_UNISTD_H)


### PR DESCRIPTION
`_Sleep' referenced in section `.text' of libargp.a(argp-parse.c.o): defined in discarded section `.text' of /.../lib/libkernel32.a(dvclds01385.o)

https://stackoverflow.com/questions/31085538/function-referenced-in-section-text-of-defined-in-discarded-section-te