### PR TITLE
rework fallback GNU functions

### DIFF
--- a/mempcpy.c
+++ b/mempcpy.c
@@ -1,7 +1,3 @@
-/* strndup.c
- *
- */
-
 /* Written by Niels Moeller <nisse@lysator.liu.se>
  *
  * This file is hereby placed in the public domain.

--- a/strcasecmp.c
+++ b/strcasecmp.c
@@ -1,3 +1,4 @@
+#include <ctype.h>
 #include <string.h>
 
 int

--- a/strchrnul.c
+++ b/strchrnul.c
@@ -1,20 +1,11 @@
-/* strchrnul.c
- *
- */
-
 /* Written by Niels Moeller <nisse@lysator.liu.se>
  *
  * This file is hereby placed in the public domain.
  */
 
-/* FIXME: What is this function supposed to do? My guess is that it is
- * like strchr, but returns a pointer to the NUL character, not a NULL
- * pointer, if the character isn't found. */
-
 char*
-strchrnul(const char* s, int c)
+strchrnul(const char* p, int c)
 {
-    const char* p = s;
     while (*p && (*p != c))
         p++;
 

--- a/strndup.c
+++ b/strndup.c
@@ -1,7 +1,3 @@
-/* strndup.c
- *
- */
-
 /* Written by Niels Moeller <nisse@lysator.liu.se>
  *
  * This file is hereby placed in the public domain.


### PR DESCRIPTION
Remove some pointless comments.
Tiny cleanup: strchrnul.c unnecessarily copied its 1st parameter to a new variable.
Fix a small bug: strcasecmp.c was missing a `#include <ctype.h>`.