### PR TITLE
set the C dialect to GNU99

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('argp-standalone', 'c',
 	version : '1.5.0',
 	license : 'LGPL-2.1-or-later',
+	default_options : ['c_std=gnu99'],
 )
 
 argp_source = files([


### PR DESCRIPTION
glibc targets GNU11. However, argp is developed closely with gnulib which targets a subset of C99, so we can assume (until CI proves otherwise, so no problem even if it's wrong) that our imported code is C99.

Ref: https://sourceware.org/git/?p=glibc.git;a=blob;f=Makeconfig;h=2514db35f6b83f6577d77a1a3068a75834f7d8bd;hb=HEAD#l1023
Ref: https://www.gnu.org/software/gnulib/manual/html_node/C-language-versions.html