### PR TITLE
CI test all branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   push:
-    branches: [master, ci]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
This makes it easier to test PRs before sending them. You don't have to use your local master branch or rename your branch to "ci".