### PR TITLE
Prepare v1.6.0 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
       - name: install mamba
         uses: mamba-org/setup-micromamba@v3
         with:
+          micromamba-version: 2.6.0-0
           environment-file: .github/meson_build_env.yml
           init-shell: ${{ runner.os == 'Windows' && 'cmd.exe' || 'bash' }}
       - name: Compile argp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,21 +14,21 @@ jobs:
 
     name: Compile and Run Tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install mamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: .github/meson_build_env.yml
+          init-shell: ${{ runner.os == 'Windows' && 'cmd.exe' || 'bash' }}
       - name: Compile argp
-        shell: bash -l {0}
         if: runner.os != 'Windows'
+        shell: bash -l {0}
         run: |
           meson setup build
           meson test -C build
       - name: Compile argp
-        shell: cmd /C CALL {0}
         if: runner.os == 'Windows'
+        shell: cmd /C CALL {0}
         run: |
-          CALL micromamba activate meson_build_env
           meson setup build
           meson test -C build

--- a/argp-fmtstream.c
+++ b/argp-fmtstream.c
@@ -116,7 +116,7 @@ weak_alias (__argp_fmtstream_free, argp_fmtstream_free)
 
 /* Process FS's buffer so that line wrapping is done from POINT_OFFS to the
    end of its buffer.  This code is mostly from glibc stdio/linewrap.c.  */
-void
+ARGP_HIDDEN void
 __argp_fmtstream_update(argp_fmtstream_t fs)
 {
     char *buf, *nl;
@@ -343,7 +343,7 @@ __argp_fmtstream_update(argp_fmtstream_t fs)
 
 /* Ensure that FS has space for AMOUNT more bytes in its buffer, either by
    growing the buffer, or by flushing it.  True is returned iff we succeed. */
-int
+ARGP_HIDDEN int
 __argp_fmtstream_ensure(struct argp_fmtstream* fs, size_t amount)
 {
     if ((size_t) (fs->end - fs->p) < amount)

--- a/argp-fmtstream.h
+++ b/argp-fmtstream.h
@@ -142,13 +142,20 @@ argp_fmtstream_printf(argp_fmtstream_t __fs, const char* __fmt, ...) PRINTF_STYL
 #define __argp_fmtstream_wmargin argp_fmtstream_wmargin
 
 /* Internal routines.  */
-extern void
+#ifndef ARGP_HIDDEN
+#if defined(__GNUC__) && !defined(_WIN32)
+#define ARGP_HIDDEN __attribute__((visibility("hidden")))
+#else
+#define ARGP_HIDDEN
+#endif
+#endif
+extern ARGP_HIDDEN void
 _argp_fmtstream_update(argp_fmtstream_t __fs);
-extern void
+extern ARGP_HIDDEN void
 __argp_fmtstream_update(argp_fmtstream_t __fs);
-extern int
+extern ARGP_HIDDEN int
 _argp_fmtstream_ensure(argp_fmtstream_t __fs, size_t __amount);
-extern int
+extern ARGP_HIDDEN int
 __argp_fmtstream_ensure(argp_fmtstream_t __fs, size_t __amount);
 
 #if 1

--- a/argp-help.c
+++ b/argp-help.c
@@ -91,7 +91,7 @@ dgettext_safe(const char* d, const char* m)
 #include "argp-namefrob.h"
 
 #ifndef SIZE_MAX
-#define SIZE_MAX ((size_t) -1)
+#define SIZE_MAX ((size_t) - 1)
 #endif
 
 /* User-selectable (using an environment variable) formatting parameters.
@@ -1360,13 +1360,16 @@ argp_hol(const struct argp* argp, struct hol_cluster* cluster)
     if (child)
         while (child->argp)
         {
-            struct hol_cluster* child_cluster
-                = ((child->group || child->header)
-                       /* Put CHILD->argp within its own cluster.  */
-                       ? hol_add_cluster(
-                           hol, child->group, child->header, child - argp->children, cluster, argp)
-                       /* Just merge it into the parent's cluster.  */
-                       : cluster);
+            struct hol_cluster* child_cluster = ((child->group || child->header)
+                                                     /* Put CHILD->argp within its own cluster.  */
+                                                     ? hol_add_cluster(hol,
+                                                                       child->group,
+                                                                       child->header,
+                                                                       child - argp->children,
+                                                                       cluster,
+                                                                       argp)
+                                                     /* Just merge it into the parent's cluster.  */
+                                                     : cluster);
             hol_append(hol, argp_hol(child->argp, child_cluster));
             child++;
         }

--- a/argp-help.c
+++ b/argp-help.c
@@ -1697,13 +1697,13 @@ __argp_help(const struct argp* argp, FILE* stream, unsigned flags, char* name)
 weak_alias(__argp_help, argp_help)
 #endif
 
-    char* __argp_basename(char* name)
+    ARGP_HIDDEN char* __argp_basename(char* name)
 {
     char* short_name = strrchr(name, '/');
     return short_name ? short_name + 1 : name;
 }
 
-char*
+ARGP_HIDDEN char*
 __argp_short_program_name(const struct argp_state* state)
 {
     if (state)
@@ -1755,10 +1755,10 @@ weak_alias(__argp_state_help, argp_state_help)
     /* If appropriate, print the printf string FMT and following args, preceded
        by the program name and `:', to stderr, and followed by a `Try ... --help'
        message, then exit (1).  */
-    void __argp_error_internal(const struct argp_state* state,
-                               const char* fmt,
-                               va_list ap,
-                               unsigned int mode_flags)
+    ARGP_HIDDEN void __argp_error_internal(const struct argp_state* state,
+                                           const char* fmt,
+                                           va_list ap,
+                                           unsigned int mode_flags)
 {
     if (!state || !(state->flags & ARGP_NO_ERRS))
     {
@@ -1818,12 +1818,12 @@ weak_alias(__argp_error, argp_error)
        difference between this function and argp_error is that the latter is for
        *parsing errors*, and the former is for other problems that occur during
        parsing but don't reflect a (syntactic) problem with the input.  */
-    void __argp_failure_internal(const struct argp_state* state,
-                                 int status,
-                                 int errnum,
-                                 const char* fmt,
-                                 va_list ap,
-                                 unsigned int mode_flags)
+    ARGP_HIDDEN void __argp_failure_internal(const struct argp_state* state,
+                                             int status,
+                                             int errnum,
+                                             const char* fmt,
+                                             va_list ap,
+                                             unsigned int mode_flags)
 {
     if (!state || !(state->flags & ARGP_NO_ERRS))
     {

--- a/argp-namefrob.h
+++ b/argp-namefrob.h
@@ -17,6 +17,14 @@
    License along with the GNU C Library; if not, see
    <https://www.gnu.org/licenses/>.  */
 
+#ifndef ARGP_HIDDEN
+#if defined(__GNUC__) && !defined(_WIN32)
+#define ARGP_HIDDEN __attribute__((visibility("hidden")))
+#else
+#define ARGP_HIDDEN
+#endif
+#endif
+
 #if 1
 /* This code is written for inclusion in gnu-libc, and uses names in the
    namespace reserved for libc.  If we're not compiling in libc, define those
@@ -144,8 +152,12 @@ void*
 mempcpy(void* to, const void* from, size_t size);
 #endif
 
-extern char*
+extern ARGP_HIDDEN char*
 __argp_basename(char* name);
+
+struct argp_state;
+extern ARGP_HIDDEN char*
+__argp_short_program_name(const struct argp_state* state);
 
 #endif /* !_LIBC */
 

--- a/argp-parse.c
+++ b/argp-parse.c
@@ -91,7 +91,7 @@ alloca();
    for one second intervals, decrementing _ARGP_HANG until it's zero.  Thus
    you can force the program to continue by attaching a debugger and setting
    it to 0 yourself.  */
-volatile int _argp_hang;
+ARGP_HIDDEN volatile int _argp_hang;
 
 #define OPT_PROGNAME -2
 #define OPT_USAGE -3

--- a/argp.h
+++ b/argp.h
@@ -567,14 +567,6 @@ reflect ARGP_LONG_ONLY mode.  */
     extern void* __argp_input(__const struct argp* __restrict __argp,
                               __const struct argp_state* __restrict __state) __THROW;
 
-    /* Used for extracting the program name from argv[0] */
-    extern char* _argp_basename(char* name) __THROW;
-    extern char* __argp_basename(char* name) __THROW;
-
-    /* Getting the program name given an argp state */
-    extern char* _argp_short_program_name(const struct argp_state* state) __THROW;
-    extern char* __argp_short_program_name(const struct argp_state* state) __THROW;
-
     // #ifdef __USE_EXTERN_INLINES
     // #if 1
     // #define __argp_usage argp_usage

--- a/compat/mempcpy.c
+++ b/compat/mempcpy.c
@@ -5,7 +5,13 @@
 
 #include <string.h>
 
-void*
+#if defined(__GNUC__) && !defined(_WIN32)
+#define ARGP_HIDDEN __attribute__((visibility("hidden")))
+#else
+#define ARGP_HIDDEN
+#endif
+
+ARGP_HIDDEN void*
 mempcpy(void* to, const void* from, size_t size)
 {
     memcpy(to, from, size);

--- a/compat/strchrnul.c
+++ b/compat/strchrnul.c
@@ -3,7 +3,13 @@
  * This file is hereby placed in the public domain.
  */
 
-char*
+#if defined(__GNUC__) && !defined(_WIN32)
+#define ARGP_HIDDEN __attribute__((visibility("hidden")))
+#else
+#define ARGP_HIDDEN
+#endif
+
+ARGP_HIDDEN char*
 strchrnul(const char* p, int c)
 {
     while (*p && (*p != c))

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,7 @@ if host_machine.system() != 'windows'
 		argp_source,
 		include_directories : '.',
 		version : meson.project_version(),
+		soversion : 1,
 		install : true
 	)
 else

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('argp-standalone', 'c',
-	version : '1.5.0',
+	version : '1.6.0',
 	license : 'LGPL-2.1-or-later',
 	default_options : ['c_std=gnu99'],
 )


### PR DESCRIPTION
Resolves #32, and as this would be the first actual release with a shared library build I also made an effort to resolve #23 to prevent symbols from leaking out that should not be relied upon.